### PR TITLE
Fix parameter passing to raw `Instance`

### DIFF
--- a/main_operator/templates/external.yaml
+++ b/main_operator/templates/external.yaml
@@ -11,4 +11,5 @@ spec:
     namespace: {{ .Namespace }}
     type: OperatorVersions
   parameters:
-    images: "{{ .Params.images }}"
+    images: |-
+{{ .Params.images | toYaml | trim | indent 6 }}

--- a/main_operator/templates/external.yaml
+++ b/main_operator/templates/external.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
     operator: external-operator
-  name: external-opereator-instance
+  name: external-operator-instance
 spec:
   operatorVersion:
     name: external-operator-0.1.0


### PR DESCRIPTION
In your original code, the value of the parameter was encoded incorrectly. It looked like this:

```
$ kubectl get instance external-opereator-instance -o yaml
apiVersion: kudo.dev/v1beta1
kind: Instance
metadata:
  name: external-opereator-instance
[...]
spec:
  operatorVersion:
    name: external-operator-0.1.0
    namespace: default
  parameters:
    images: '[example/x:test example/y:test example/z:test]'
[...]
```

I think this is how Go templates stringifies an array of strings. But it's not valid YAML or JSON.

I changed this to using `toYaml` and it seems to work OK:

```
$ kubectl kudo install --skip-instance ./external_operator/
operator.kudo.dev/v1beta1/external-operator created
operatorversion.kudo.dev/v1beta1/external-operator-0.1.0 created
$ kubectl kudo install ./main_operator/
operator.kudo.dev/v1beta1/main-operator created
operatorversion.kudo.dev/v1beta1/main-operator-0.1.0 created
instance.kudo.dev/v1beta1/main-operator-instance created
$ kubectl get instance external-operator-instance -o yaml
apiVersion: kudo.dev/v1beta1
kind: Instance
metadata:
  name: external-operator-instance
[...]
spec:
  operatorVersion:
    name: external-operator-0.1.0
    namespace: default
  parameters:
    images: |-
      - example/x:test
      - example/y:test
      - example/z:test
[...]
$ kubectl get configmap -o json|jq -r '.items[]|.metadata.name,.data."config.yaml"'
example-config-custom
images:
- example/x:test
- example/y:test
- example/z:test
example-config-range
images:
- example/x:test
- example/y:test
- example/z:test
example-config-toyaml
images:
  - example/x:test
  - example/y:test
  - example/z:test
```